### PR TITLE
💚 Remove npm publish provenance flag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
-      - run: npm i --ignore-scripts
+      - run: npm ci --ignore-scripts
       - run: npm run build
       - run: mv dist/* ./ 
-      - run: npm publish --access public --provenance
+      - run: npm publish


### PR DESCRIPTION
Package is publish with provenance by default when having trusted publishing

REDMINE-100208